### PR TITLE
Add pyautogui click loop example

### DIFF
--- a/click_image.py
+++ b/click_image.py
@@ -5,8 +5,8 @@ import pyautogui
 import keyboard
 
 
-def main():
-    target_image = "target_image.png"  # replace with your image file
+def click_until_escape(target_image: str = "target_image.png", interval: float = 0.2) -> None:
+    """Repeatedly search and click ``target_image`` until ESC is pressed."""
     print("Press ESC to stop.")
     while True:
         if keyboard.is_pressed("esc"):
@@ -17,7 +17,11 @@ def main():
         if location:
             pyautogui.click(location)
 
-        time.sleep(0.2)
+        time.sleep(interval)
+
+
+def main():
+    click_until_escape()
 
 
 if __name__ == "__main__":

--- a/click_image.py
+++ b/click_image.py
@@ -1,0 +1,27 @@
+import time
+import sys
+
+import pyautogui
+import keyboard
+
+
+def main():
+    target_image = "target_image.png"  # replace with your image file
+    print("Press ESC to stop.")
+    while True:
+        if keyboard.is_pressed("esc"):
+            print("ESC pressed. Exiting.")
+            break
+
+        location = pyautogui.locateCenterOnScreen(target_image, confidence=0.8)
+        if location:
+            pyautogui.click(location)
+
+        time.sleep(0.2)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/tests/test_click_image.py
+++ b/tests/test_click_image.py
@@ -1,0 +1,29 @@
+import sys
+import unittest
+from unittest import mock
+
+sys.modules['pyautogui'] = mock.MagicMock()
+sys.modules['keyboard'] = mock.MagicMock()
+
+import click_image
+
+class ClickImageTests(unittest.TestCase):
+    def test_click_invoked_when_image_found(self):
+        with mock.patch('click_image.keyboard.is_pressed', side_effect=[False, True]), \
+             mock.patch('click_image.pyautogui.locateCenterOnScreen', side_effect=[(10, 10), None]), \
+             mock.patch('click_image.pyautogui.click') as mock_click, \
+             mock.patch('click_image.time.sleep'):
+            click_image.click_until_escape('img.png', interval=0)
+            mock_click.assert_called_once_with((10, 10))
+
+    def test_loop_stops_on_escape(self):
+        with mock.patch('click_image.keyboard.is_pressed', side_effect=[True]), \
+             mock.patch('click_image.pyautogui.locateCenterOnScreen') as mock_loc, \
+             mock.patch('click_image.pyautogui.click') as mock_click, \
+             mock.patch('click_image.time.sleep'):
+            click_image.click_until_escape('img.png', interval=0)
+            mock_loc.assert_not_called()
+            mock_click.assert_not_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a small `click_image.py` sample that demonstrates clicking an image using pyautogui

## Testing
- `python -m py_compile click_image.py`

------
https://chatgpt.com/codex/tasks/task_e_6845a0f94e80832bb1b5ef5dca3667fe