### PR TITLE
Add daily fortune script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ You can also play a simple Tetris clone by running `python tetris.py`. The game
 uses the arrow keys for movement and rotation. Lines cleared will increase your
 score.
 
+For a fun daily message execute `python fortune.py` to see today's fortune.
+

--- a/fortune.py
+++ b/fortune.py
@@ -1,0 +1,27 @@
+import datetime
+import random
+
+FORTUNES = [
+    "大吉: 素晴らしい一日になるでしょう。",
+    "中吉: 良いことが起こりそうです。",
+    "小吉: 平穏な一日になるでしょう。",
+    "吉: 何か新しい発見があるかもしれません。",
+    "凶: 無理せず慎重に過ごしましょう。",
+]
+
+
+def get_daily_fortune(date: datetime.date | None = None) -> str:
+    """Return a deterministic fortune for the given date."""
+    if date is None:
+        date = datetime.date.today()
+    random.seed(date.toordinal())
+    return random.choice(FORTUNES)
+
+
+def main() -> None:
+    fortune = get_daily_fortune()
+    print(f"本日の運勢: {fortune}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_fortune.py
+++ b/tests/test_fortune.py
@@ -1,0 +1,17 @@
+import datetime
+import unittest
+
+import fortune
+
+
+class FortuneTests(unittest.TestCase):
+    def test_deterministic_for_same_date(self):
+        date = datetime.date(2024, 1, 1)
+        first = fortune.get_daily_fortune(date)
+        second = fortune.get_daily_fortune(date)
+        self.assertEqual(first, second)
+        self.assertIn(first, fortune.FORTUNES)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `fortune.py` which prints today's fortune in Japanese
- document the new script in the README
- add unit test for deterministic fortune selection

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481e232140832b93220febda8961ff